### PR TITLE
✨ feat(course-detail): 調整課程詳情頁面樣式與邏輯

### DIFF
--- a/src/app/pages/layout/course-detail/course-detail.html
+++ b/src/app/pages/layout/course-detail/course-detail.html
@@ -195,7 +195,7 @@
     <div
       class="flex flex-col gap-6 pb-12 pt-6 xl:container xl:mx-auto xl:w-320 xl:flex-row xl:pb-20 xl:pt-10"
     >
-      <div class="mb-6 flex flex-col gap-12 xl:min-w-[845px] xl:pr-6">
+      <div class="mb-6 flex flex-col gap-12 xl:w-[845px] xl:pr-6">
         <!-- 課程介紹 -->
         <section id="sectionA" #section>
           <tmf-course-detail-section-title
@@ -328,7 +328,7 @@
                   <li>
                     {{ education.start_year }}-{{
                       education.end_year || "至今"
-                    }}｜{{ education.school_name }}｜{{ education.degree }}
+                    }}｜{{ education.school_name }}｜{{ education.degree! | degree }}
                   </li>
                 }
               </ul>
@@ -359,7 +359,7 @@
       </div>
 
       <!-- 課程方案 -->
-      <div class="w-full">
+      <div class="grow">
         <div
           class="flex flex-col gap-3 rounded-xl border border-grey-d4 bg-white p-3 xl:gap-6 xl:border-0 xl:p-6 xl:shadow-lg"
         >

--- a/src/app/pages/layout/course-detail/course-detail.ts
+++ b/src/app/pages/layout/course-detail/course-detail.ts
@@ -17,6 +17,7 @@ import { VideoCard, VideoCardData } from '@components/video-card/video-card';
 import { VideoViewerDialogComponent } from '@components/dialogs/video-viewer/video-viewer-dialog';
 import { AllReviewsDialogComponent } from '@components/dialogs/all-reviews-dialog/all-reviews-dialog';
 import { Subject } from 'rxjs';
+import { DegreePipe } from "../../../../shared/pipes/degree.pipe";
 
 @Component({
   selector: 'tmf-course-detail',
@@ -31,7 +32,8 @@ import { Subject } from 'rxjs';
     WeeklyCalendar,
     InputPlan,
     VideoCard,
-  ],
+    DegreePipe
+],
   templateUrl: './course-detail.html',
   styles: `
     .active {


### PR DESCRIPTION
調整項目：
1. 課程詳情頁面中，將課程介紹區塊的寬度設定為 845px。
2. 更新學歷顯示邏輯，使用 DegreePipe 格式化學位顯示。
3. 課程方案區塊的樣式調整為自動擴展以適應內容。

這些變更提升了頁面的可讀性與一致性。